### PR TITLE
Fix #303: Pravda that has run from expload-pravda-node Dockerfile doesn't use application.conf

### DIFF
--- a/docker/images/expload-pravda-node/Dockerfile
+++ b/docker/images/expload-pravda-node/Dockerfile
@@ -19,17 +19,16 @@ copy yopt    yopt
 copy project project
 copy build.sbt build.sbt
 
-run cd /build && SBT_OPTS="-Xmx2G -Xms2G -XX:+UseConcMarkSweepGC -XX:+CMSClassUnloadingEnabled -Xss2M" sbt cli/stage
+run cd /build && SBT_OPTS="-Xmx2G -Xms2G -XX:+UseConcMarkSweepGC -XX:+CMSClassUnloadingEnabled -Xss2M" sbt node/stage
 
 from openjdk:8u171
 
-workdir /pravda-cli
+workdir /node
 
-copy --from=builder build/cli/target/universal/stage/lib lib
-copy --from=builder build/cli/target/universal/stage/bin bin
+copy --from=builder build/node/target/universal/stage/lib lib
+copy --from=builder build/node/target/universal/stage/bin bin
 
-copy docker/images/expload-pravda-node/coin-distr.json /pravda-cli
-copy docker/images/expload-pravda-node/application.conf /pravda-cli
-copy docker/images/expload-pravda-node/entry.sh /pravda-cli
+copy docker/images/expload-pravda-node/application.conf /node
+copy docker/images/expload-pravda-node/entry.sh /node
 
-entrypoint [ "/pravda-cli/entry.sh" ]
+entrypoint [ "/node/entry.sh" ]

--- a/docker/images/expload-pravda-node/application.conf
+++ b/docker/images/expload-pravda-node/application.conf
@@ -29,7 +29,7 @@ pravda {
     distribution = false
     distribution = ${?PRAVDA_DISTRIBUTION}
   }
-  payment-wallet {
+  validator {
     private-key = ${?PRAVDA_VALIDATOR_SK}
     address = ${?PRAVDA_VALIDATOR_PK}
   }

--- a/docker/images/expload-pravda-node/entry.sh
+++ b/docker/images/expload-pravda-node/entry.sh
@@ -22,18 +22,19 @@ fi
 sed -i "s/PRAVDA_COIN_HOLDER_2/$PRAVDA_COIN_HOLDER_2/g" /pravda-cli/coin-distr.json
 sed -i "s/PRAVDA_COIN_HOLDER/$PRAVDA_COIN_HOLDER/g" /pravda-cli/coin-distr.json
 
-if [ -z "$(ls -A /node-data)" ]; then
-  echo "/node-data does not exist, creating"
-  mkdir -p /node-data
+if [ -z "$(ls -A ${PRAVDA_DATA})" ]; then
+  echo "${PRAVDA_DATA} does not exist, creating"
+  mkdir -p ${PRAVDA_DATA}
 fi
 
 if [ ! -f /node-data/initialized ]; then
   echo "Initializing node"
-  rm -rf /node-data/*
-  /pravda-cli/bin/pravda node init --data-dir /node-data --coin-distribution coin-distr.json
-  echo yes > /node-data/initialized
+  rm -rf ${PRAVDA_DATA}/*
+  /pravda-cli/bin/pravda node init --data-dir ${PRAVDA_DATA} --coin-distribution coin-distr.json
+  echo yes > ${PRAVDA_DATA}/initialized
 fi
 
 echo "Starting node"
 export TC_CONFIG_FILE=/pravda-cli/application.conf
-/pravda-cli/bin/pravda node run --data-dir /node-data
+
+exec java -classpath /pravda-cli/lib/"*" -Dconfig.file=/pravda-cli/application.conf pravda.node.launcher $@

--- a/docker/images/expload-pravda-node/entry.sh
+++ b/docker/images/expload-pravda-node/entry.sh
@@ -2,39 +2,6 @@
 
 set -e
 
-if [ -z "$PRAVDA_COIN_HOLDER" ]
-then
-  echo "Please specify public key in \$PRAVDA_COIN_HOLDER to perform initial coin distribution"
-  exit 1
-else
-  echo "Giving money to $PRAVDA_COIN_HOLDER"
-fi
-
-if [ -z "$PRAVDA_COIN_HOLDER_2" ]
-then
-  echo "Please specify public key in \$PRAVDA_COIN_HOLDER_2 to perform initial coin distribution"
-  exit 1
-else
-  echo "Giving money to $PRAVDA_COIN_HOLDER_2"
-fi
-
-# More specific regular expressions should follow before
-sed -i "s/PRAVDA_COIN_HOLDER_2/$PRAVDA_COIN_HOLDER_2/g" /pravda-cli/coin-distr.json
-sed -i "s/PRAVDA_COIN_HOLDER/$PRAVDA_COIN_HOLDER/g" /pravda-cli/coin-distr.json
-
-if [ -z "$(ls -A ${PRAVDA_DATA})" ]; then
-  echo "${PRAVDA_DATA} does not exist, creating"
-  mkdir -p ${PRAVDA_DATA}
-fi
-
-if [ ! -f /node-data/initialized ]; then
-  echo "Initializing node"
-  rm -rf ${PRAVDA_DATA}/*
-  /pravda-cli/bin/pravda node init --data-dir ${PRAVDA_DATA} --coin-distribution coin-distr.json
-  echo yes > ${PRAVDA_DATA}/initialized
-fi
-
 echo "Starting node"
-export TC_CONFIG_FILE=/pravda-cli/application.conf
 
-exec java -classpath /pravda-cli/lib/"*" -Dconfig.file=/pravda-cli/application.conf pravda.node.launcher $@
+exec java -classpath /node/lib/"*" -Dconfig.file=/node/application.conf pravda.node.launcher $@


### PR DESCRIPTION
In commit 7a2ddc8: Using of pravda-cli was removed. Initial coin distribution should be done with environment variable `PRAVDA_COIN_DISTRIBUTION` instead of using `pravd node init` command 