### PR TITLE
Close #415: Add new API endpoints for events, transferEffects and transactions by address

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,5 +7,7 @@ target/
 .settings/
 *.iml
 development.conf
-PravdaDotNet/
-PravdaProgramTemplate/
+PravdaDotNet/bin/
+PravdaDotNet/obj/
+PravdaProgramTemplate/Content/bin
+PravdaProgramTemplate/Content/obj

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ target/
 .settings/
 *.iml
 development.conf
+PravdaDotNet/
+PravdaProgramTemplate/

--- a/node/src/main/scala/pravda/node/data/serialization/TethysInstances.scala
+++ b/node/src/main/scala/pravda/node/data/serialization/TethysInstances.scala
@@ -38,7 +38,6 @@ import pravda.common.json._
 import pravda.node.data.cryptography.EncryptedPrivateKey
 import pravda.node.data.domain.Wallet
 import pravda.vm.json._
-
 import pravda.common.bytes.{byteString2hex, hex2byteString}
 
 trait TethysInstances {
@@ -145,6 +144,18 @@ trait TethysInstances {
 
   implicit val eventItemWriter: JsonWriter[ApiRoute.EventItem] =
     jsonWriter[ApiRoute.EventItem]
+
+  implicit val additionalDataReader: JsonReader[Abci.AdditionalDataForAddress] =
+    jsonReader[Abci.AdditionalDataForAddress]
+
+  implicit val additionalDataWriter: JsonWriter[Abci.AdditionalDataForAddress] =
+    jsonWriter[Abci.AdditionalDataForAddress]
+
+  implicit val transactionEffectsReader: JsonReader[Abci.TransactionEffects] =
+    jsonReader[Abci.TransactionEffects]
+
+  implicit val transactionEffectsWriter: JsonWriter[Abci.TransactionEffects] =
+    jsonWriter[Abci.TransactionEffects]
 
   //---------------------------------------------------------------------------
   // ABCI

--- a/node/src/main/scala/pravda/node/data/serialization/TethysInstances.scala
+++ b/node/src/main/scala/pravda/node/data/serialization/TethysInstances.scala
@@ -151,11 +151,37 @@ trait TethysInstances {
   implicit val additionalDataWriter: JsonWriter[Abci.AdditionalDataForAddress] =
     jsonWriter[Abci.AdditionalDataForAddress]
 
+  implicit val transferEffectsReader: JsonReader[Abci.TransactionEffects.Transfers] =
+    jsonReader[Abci.TransactionEffects.Transfers]
+
+  implicit val transferEffectsWriter: JsonObjectWriter[Abci.TransactionEffects.Transfers] =
+    jsonWriter[Abci.TransactionEffects.Transfers]
+
+  implicit val programEventsReader: JsonReader[Abci.TransactionEffects.ProgramEvents] =
+    jsonReader[Abci.TransactionEffects.ProgramEvents]
+
+  implicit val programEventsWriter: JsonObjectWriter[Abci.TransactionEffects.ProgramEvents] =
+    jsonWriter[Abci.TransactionEffects.ProgramEvents]
+
+  implicit val transactionAllEffectsReader: JsonReader[Abci.TransactionEffects.AllEffects] =
+    jsonReader[Abci.TransactionEffects.AllEffects]
+
+  implicit val transactionAllEffectsWriter: JsonObjectWriter[Abci.TransactionEffects.AllEffects] =
+    jsonWriter[Abci.TransactionEffects.AllEffects]
+
   implicit val transactionEffectsReader: JsonReader[Abci.TransactionEffects] =
-    jsonReader[Abci.TransactionEffects]
+    JsonReader.builder
+      .addField[String]("transactionEffectsType")
+      .selectReader[Abci.TransactionEffects] {
+        case Abci.TransactionEffects.Transfers.identifier     => jsonReader[Abci.TransactionEffects.Transfers]
+        case Abci.TransactionEffects.ProgramEvents.identifier => jsonReader[Abci.TransactionEffects.ProgramEvents]
+        case Abci.TransactionEffects.AllEffects.identifier    => jsonReader[Abci.TransactionEffects.AllEffects]
+      }
 
   implicit val transactionEffectsWriter: JsonWriter[Abci.TransactionEffects] =
-    jsonWriter[Abci.TransactionEffects]
+    JsonWriter
+      .obj[Abci.TransactionEffects]
+      .addField[String]("transactionEffectsType")(_.identifier) ++ jsonWriter[Abci.TransactionEffects]
 
   //---------------------------------------------------------------------------
   // ABCI

--- a/node/src/main/scala/pravda/node/data/serialization/bjson.scala
+++ b/node/src/main/scala/pravda/node/data/serialization/bjson.scala
@@ -34,5 +34,8 @@ trait BJsonTranscoder {
     t => BJson @@ t.asJson.getBytes(StandardCharsets.UTF_8)
 
   implicit def bjsonDecoder[T: JsonReader]: BJsonDecoder[T] =
-    t => new String(t, StandardCharsets.UTF_8).jsonAs[T].fold(throw _, identity)
+    t => {
+      val str = new String(t, StandardCharsets.UTF_8)
+      str.jsonAs[T].fold(e => throw new RuntimeException(s"Error while parsing json: $str", e), identity)
+    }
 }

--- a/node/src/main/scala/pravda/node/persistence/BlockChainStore.scala
+++ b/node/src/main/scala/pravda/node/persistence/BlockChainStore.scala
@@ -25,6 +25,7 @@ import pravda.node.persistence.implicits._
 object BlockChainStore {
   def balanceEntry(db: DB): Entry[Address, NativeCoin] = Entry[Address, NativeCoin](db, "balance")
   def transferEffectsEntry(db: DB): DbPath = new PureDbPath(db, "transferEffectsByAddress")
-  def eventsEntry(db: DB): DbPath = new PureDbPath(db, "eventsByAddress")
+  def eventsByAddressEntry(db: DB): DbPath = new PureDbPath(db, "eventsByAddress")
+  def eventsEntry(db: DB): DbPath = new PureDbPath(db, "events")
   def transactionsEntry(db: DB): DbPath = new PureDbPath(db, "transactionsByAddress")
 }

--- a/node/src/main/scala/pravda/node/persistence/BlockChainStore.scala
+++ b/node/src/main/scala/pravda/node/persistence/BlockChainStore.scala
@@ -21,7 +21,11 @@ import pravda.common.domain.{Address, NativeCoin}
 import pravda.node.db.DB
 import pravda.node.persistence.implicits._
 import pravda.node.data.serialization.json._
+import pravda.node.servers.Abci.TransactionEffects
 
 object BlockChainStore {
   def balanceEntry(db: DB): Entry[Address, NativeCoin] = Entry[Address, NativeCoin](db, "balance")
+  def transferEffectsEntry(db: DB) = Entry[Address, Seq[TransactionEffects]](db, "transferEffectsByAddress")
+  def eventsEntry(db: DB) = Entry[Address, Seq[TransactionEffects]](db, "eventsByAddress")
+  def transactionsEntry(db: DB) = Entry[Address, Seq[TransactionEffects]](db, "transactionsByAddress")
 }

--- a/node/src/main/scala/pravda/node/persistence/BlockChainStore.scala
+++ b/node/src/main/scala/pravda/node/persistence/BlockChainStore.scala
@@ -18,14 +18,13 @@
 package pravda.node.persistence
 
 import pravda.common.domain.{Address, NativeCoin}
+import pravda.node.data.serialization.json._
 import pravda.node.db.DB
 import pravda.node.persistence.implicits._
-import pravda.node.data.serialization.json._
-import pravda.node.servers.Abci.TransactionEffects
 
 object BlockChainStore {
   def balanceEntry(db: DB): Entry[Address, NativeCoin] = Entry[Address, NativeCoin](db, "balance")
-  def transferEffectsEntry(db: DB) = Entry[Address, Seq[TransactionEffects]](db, "transferEffectsByAddress")
-  def eventsEntry(db: DB) = Entry[Address, Seq[TransactionEffects]](db, "eventsByAddress")
-  def transactionsEntry(db: DB) = Entry[Address, Seq[TransactionEffects]](db, "transactionsByAddress")
+  def transferEffectsEntry(db: DB): DbPath = new PureDbPath(db, "transferEffectsByAddress")
+  def eventsEntry(db: DB): DbPath = new PureDbPath(db, "eventsByAddress")
+  def transactionsEntry(db: DB): DbPath = new PureDbPath(db, "transactionsByAddress")
 }

--- a/node/src/main/scala/pravda/node/persistence/DbPath.scala
+++ b/node/src/main/scala/pravda/node/persistence/DbPath.scala
@@ -17,13 +17,15 @@
 
 package pravda.node.persistence
 
-import pravda.node.data.serialization.{BJson, transcode}
-import pravda.node.db.{DB, Operation}
-
-import scala.collection.mutable
 import pravda.common.{bytes => byteUtils}
 import pravda.node.data.serialization.bjson._
+import pravda.node.data.serialization.{BJson, transcode}
+import pravda.node.db.serialyzer.KeyWriter
+import pravda.node.db.{DB, Operation}
 import tethys.{JsonReader, JsonWriter}
+
+import scala.collection.mutable
+import scala.concurrent.{ExecutionContext, Future}
 
 trait DbPath {
 
@@ -44,6 +46,14 @@ trait DbPath {
   def putRawBytes(suffix: String, value: Array[Byte]): Option[Array[Byte]]
 
   def remove(suffix: String): Option[Array[Byte]]
+
+  def startsWith[V: JsonReader: JsonWriter](suffix: String, offset: Long, count: Long)(
+      implicit keyWriter: KeyWriter[String],
+      ec: ExecutionContext): Future[List[V]]
+
+  def startsWith[V: JsonReader: JsonWriter](suffix: String, offset: Long)(implicit keyWriter: KeyWriter[String],
+                                                                          ec: ExecutionContext): Future[List[V]] =
+    startsWith(suffix, offset, Long.MaxValue)
 
   protected def returningPrevious(suffix: String)(f: => Unit): Option[Array[Byte]] = {
     val prev = getRawBytes(suffix)
@@ -76,6 +86,12 @@ class CachedDbPath(dbPath: DbPath,
     dbCache.put(key, None)
   }
 
+  def startsWith[V: JsonReader: JsonWriter](suffix: String, offset: Long, count: Long)(
+      implicit keyWriter: KeyWriter[String],
+      ec: ExecutionContext) = {
+    // Delegate to pure db
+    dbPath.startsWith(suffix, offset, count)
+  }
 }
 
 class PureDbPath(db: DB, path: String) extends DbPath {
@@ -99,4 +115,17 @@ class PureDbPath(db: DB, path: String) extends DbPath {
     db.syncDeleteBytes(byteUtils.stringToBytes(key))
   }
 
+  def startsWith[V: JsonReader: JsonWriter](suffix: String, offset: Long, count: Long)(
+      implicit keyWriter: KeyWriter[String],
+      ec: ExecutionContext): Future[List[V]] = {
+    val key = mkKey(suffix)
+    val offsetKey = key + ":" + f"$offset%016x"
+
+    db.startsWith(key, offsetKey, count).map { records =>
+      records.map(
+        value =>
+          transcode(BJson @@ value.bytes)
+            .to[V])
+    }
+  }
 }

--- a/node/src/main/scala/pravda/node/servers/Abci.scala
+++ b/node/src/main/scala/pravda/node/servers/Abci.scala
@@ -292,15 +292,8 @@ object Abci {
                                         transactionId: TransactionId,
                                         effects: Seq[Effect],
                                         transactionNumber: Long): Unit = {
-        val hexAddr = byteUtils.byteString2hex(address)
-        val previousValue =
-          dbPath
-            .getAs[Seq[TransactionEffects]](hexAddr)
-            .fold(Seq.empty[TransactionEffects])(identity)
-        dbPath.put(
-          hexAddr,
-          previousValue :+ TransactionEffects(transactionNumber, transactionId, effects)
-        )
+        val key = keyWithOffset(byteUtils.byteString2hex(address), transactionNumber - 1)
+        dbPath.put(key, TransactionEffects(transactionNumber, transactionId, effects))
       }
 
       private def getAdditionalDataByAddress(addr: Address): AdditionalDataForAddress =
@@ -561,4 +554,5 @@ object Abci {
 
   }
 
+  def keyWithOffset(key: String, offset: Long) = f"$key:$offset%016x"
 }

--- a/node/src/main/scala/pravda/node/servers/ApiRoute.scala
+++ b/node/src/main/scala/pravda/node/servers/ApiRoute.scala
@@ -268,7 +268,7 @@ class ApiRoute(abciClient: AbciClient, db: DB, abci: Abci)(implicit executionCon
                   val offset = maybeOffset.getOrElse(0L)
                   val count = maybeCount.fold(ApiRoute.MaxRecordsCount)(math.min(_, ApiRoute.MaxRecordsCount))
 
-                  val eventuallyResult = transferEffectsByAddress.startsWith[TransactionEffects](
+                  val eventuallyResult = transferEffectsByAddress.startsWith[TransactionEffects.Transfers](
                     bytes.byteString2hex(address),
                     offset,
                     count
@@ -290,7 +290,7 @@ class ApiRoute(abciClient: AbciClient, db: DB, abci: Abci)(implicit executionCon
                     val offset = maybeOffset.getOrElse(0L)
                     val count = maybeCount.fold(ApiRoute.MaxRecordsCount)(math.min(_, ApiRoute.MaxRecordsCount))
 
-                    val eventuallyResult = eventsByAddress.startsWith[TransactionEffects](
+                    val eventuallyResult = eventsByAddress.startsWith[TransactionEffects.ProgramEvents](
                       bytes.byteString2hex(address),
                       offset,
                       count
@@ -311,7 +311,7 @@ class ApiRoute(abciClient: AbciClient, db: DB, abci: Abci)(implicit executionCon
                     val offset = maybeOffset.getOrElse(0L)
                     val count = maybeCount.fold(ApiRoute.MaxRecordsCount)(math.min(_, ApiRoute.MaxRecordsCount))
 
-                    val eventuallyResult = transactionsByAddress.startsWith[TransactionEffects](
+                    val eventuallyResult = transactionsByAddress.startsWith[TransactionEffects.AllEffects](
                       bytes.byteString2hex(address),
                       offset,
                       count

--- a/node/src/main/scala/pravda/node/servers/ApiRoute.scala
+++ b/node/src/main/scala/pravda/node/servers/ApiRoute.scala
@@ -268,11 +268,12 @@ class ApiRoute(abciClient: AbciClient, db: DB, abci: Abci)(implicit executionCon
                   val offset = maybeOffset.getOrElse(0L)
                   val count = maybeCount.fold(ApiRoute.MaxRecordsCount)(math.min(_, ApiRoute.MaxRecordsCount))
 
-                  val eventuallyResult = transferEffectsByAddress.startsWith[TransactionEffects.Transfers](
-                    bytes.byteString2hex(address),
-                    offset,
-                    count
-                  )
+                  val eventuallyResult =
+                    transferEffectsByAddress.startsWith[TransactionEffects.Transfers](
+                      bytes.byteString2hex(address),
+                      offset,
+                      count
+                    )
 
                   onSuccess(eventuallyResult)(complete(_))
                 }

--- a/vm-api/src/main/scala/pravda/vm/TethysInstances.scala
+++ b/vm-api/src/main/scala/pravda/vm/TethysInstances.scala
@@ -274,6 +274,7 @@ trait TethysInstances {
       case "Transfer"      => jsonReader[vm.Effect.Transfer]
     }
 
+  implicit val effectEventReader: JsonReader[vm.Effect.Event] = jsonReader[vm.Effect.Event]
   implicit val effectEventWriter: JsonObjectWriter[vm.Effect.Event] = jsonWriter[vm.Effect.Event]
 
   implicit val effectProgramCreateWriter: JsonObjectWriter[vm.Effect.ProgramCreate] =
@@ -293,6 +294,7 @@ trait TethysInstances {
 
   implicit val effectStorageWriteWriter: JsonObjectWriter[vm.Effect.StorageWrite] = jsonWriter[vm.Effect.StorageWrite]
 
+  implicit val effectTransferReader: JsonReader[vm.Effect.Transfer] = jsonReader[vm.Effect.Transfer]
   implicit val effectTransferWriter: JsonObjectWriter[vm.Effect.Transfer] = jsonWriter[vm.Effect.Transfer]
 
   implicit val effectWriter: JsonWriter[vm.Effect] =


### PR DESCRIPTION
The following three endpoints have been added:

- /api/public/account/$pubKey/transfers
- /api/public/account/$pubKey/events
- /api/public/account/$pubKey/transactions

The sample output could like this:

```
curl -X GET "localhost:8080/api/public/account/a4b6e44ddd94b7ceee9b38c5e1f05c9509688288b8328e63a4cdc7defeaa2a7b/transfers"
[ {
  "num" : 1,
  "transactionId" : "00bcf184f9fe9c3801f9c3460124d3b847819297",
  "effects" : [ {
    "eventType" : "Transfer",
    "from" : "dc5056337b83726b881f241bf534ca04f7694452e0e879018872679cf8815af4",
    "to" : "a4b6e44ddd94b7ceee9b38c5e1f05c9509688288b8328e63a4cdc7defeaa2a7b",
    "amount" : 10000
  } ]
}, {
  "num" : 2,
  "transactionId" : "8c09df991e6523d4bca7e48aef6ca755818a4858",
  "effects" : [ {
    "eventType" : "Transfer",
    "from" : "dc5056337b83726b881f241bf534ca04f7694452e0e879018872679cf8815af4",
    "to" : "a4b6e44ddd94b7ceee9b38c5e1f05c9509688288b8328e63a4cdc7defeaa2a7b",
    "amount" : 10000
  } ]
}, {
  "num" : 3,
  "transactionId" : "536a0af9e0c62574034de9ec52b4b995f22c331c",
  "effects" : [ {
    "eventType" : "Transfer",
    "from" : "a4b6e44ddd94b7ceee9b38c5e1f05c9509688288b8328e63a4cdc7defeaa2a7b",
    "to" : "dc5056337b83726b881f241bf534ca04f7694452e0e879018872679cf8815af4",
    "amount" : 50
  } ]
}
```